### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
     environment: PUBLISH
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -52,5 +53,3 @@ jobs:
 
       - name: Publish package
         run: bun run release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tests/workflow-security.test.ts
+++ b/tests/workflow-security.test.ts
@@ -9,7 +9,7 @@ const pullRequestTriggerPattern = /^\s*pull_request:\s*$/m
 const readOnlyPermissionsPattern = /^permissions:\n\s+contents: read$/m
 const persistedCredentialsPattern = /persist-credentials: false/g
 const publishEnvironmentPattern = /^\s+environment: PUBLISH$/m
-const publishPermissionsPattern = /^\s+permissions:\n\s+contents: read$/m
+const publishPermissionsPattern = /^\s+permissions:\n\s+contents: read\n\s+id-token: write$/m
 const releasePermissionsPattern = /^permissions:\n\s+contents: write\n\s+pull-requests: write$/m
 
 function readWorkflow(name: (typeof workflowNames)[number]): Promise<string> {
@@ -39,7 +39,7 @@ describe("GitHub Actions security", () => {
     expect(workflow.match(persistedCredentialsPattern)).toHaveLength(2)
   })
 
-  test("limits publishing to the merged canonical release PR", async () => {
+  test("limits trusted publishing to the merged canonical release PR", async () => {
     const workflow = await readWorkflow("publish.yml")
 
     expect(workflow).toContain("github.repository == 'hack-dance/schema-stream'")
@@ -51,6 +51,9 @@ describe("GitHub Actions security", () => {
     expect(workflow).toMatch(publishPermissionsPattern)
     expect(workflow).toContain("persist-credentials: false")
     expect(workflow).not.toContain("contents: write")
+    expect(workflow).not.toContain("NODE_AUTH_TOKEN")
+    expect(workflow).not.toContain("NPM_TOKEN")
+    expect(workflow).not.toContain("secrets.")
   })
 
   test("scopes release automation to the canonical repository", async () => {


### PR DESCRIPTION
## What changed

- grant the publish job the OIDC permission required by npm trusted publishing
- remove the long-lived `NPM_TOKEN` from the workflow
- extend the workflow security test to require OIDC and reject npm secrets

## Why

The `4.1.0` release reached npm but failed because the standalone repository was still using a token that cannot publish `schema-stream`. Island AI already publishes this package through npm's repository-bound trusted publisher; the standalone workflow should use the same short-lived credential model.

The npm trusted-publisher binding must target `hack-dance/schema-stream`, `publish.yml`, and the `PUBLISH` environment.

## Validation

- `bun run format`
- `bun run lint`
- `bun test tests/workflow-security.test.ts`
- `bun run type-check`
- `git diff --check`
