### PR TITLE
Add guarded publish recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - closed
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -13,10 +14,13 @@ jobs:
   publish:
     if: >-
       github.repository == 'hack-dance/schema-stream' &&
-      github.event.pull_request.merged == true &&
-      github.base_ref == 'main' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.head_ref == 'changeset-release/main'
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.base_ref == 'main' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.head_ref == 'changeset-release/main') ||
+       (github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
     environment: PUBLISH
     permissions:

--- a/tests/workflow-security.test.ts
+++ b/tests/workflow-security.test.ts
@@ -39,7 +39,7 @@ describe("GitHub Actions security", () => {
     expect(workflow.match(persistedCredentialsPattern)).toHaveLength(2)
   })
 
-  test("limits trusted publishing to the merged canonical release PR", async () => {
+  test("limits trusted publishing to canonical release paths", async () => {
     const workflow = await readWorkflow("publish.yml")
 
     expect(workflow).toContain("github.repository == 'hack-dance/schema-stream'")
@@ -47,6 +47,8 @@ describe("GitHub Actions security", () => {
     expect(workflow).toContain("github.base_ref == 'main'")
     expect(workflow).toContain("github.event.pull_request.head.repo.full_name == github.repository")
     expect(workflow).toContain("github.head_ref == 'changeset-release/main'")
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'")
+    expect(workflow).toContain("github.ref == 'refs/heads/main'")
     expect(workflow).toMatch(publishEnvironmentPattern)
     expect(workflow).toMatch(publishPermissionsPattern)
     expect(workflow).toContain("persist-credentials: false")


### PR DESCRIPTION
## What changed

- add a manual recovery trigger to the trusted-publishing workflow
- allow that trigger only from the canonical repository's `main` branch
- retain the existing exact release-PR checks and `PUBLISH` environment gate
- test both authorized release paths

## Why

The first standalone `4.1.0` publish failed before trusted publishing was enabled. GitHub reruns use the original workflow revision, so a guarded manual trigger is needed to retry with the corrected OIDC workflow without manufacturing another release PR.

## Validation

- `bun run format`
- `bun run lint`
- `bun test tests/workflow-security.test.ts`
- `bun run type-check`
- `git diff --check`
