### PR TITLE
Update package homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Progressively parse streamed JSON into typed, schema-shaped snapshots",
   "author": "Dimitri Kennedy <dimitri@sick.email> (https://hack.dance)",
   "license": "MIT",
-  "homepage": "https://github.com/hack-dance/schema-stream#readme",
+  "homepage": "https://hack.dance",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hack-dance/schema-stream.git"


### PR DESCRIPTION
## What changed

- point the package homepage at `https://hack.dance`
- verify the repository and bugs URLs already target `hack-dance/schema-stream`

## Why

The unpublished `4.1.0` package should replace the legacy Island AI metadata before the first standalone-repository publication.

## Validation

- `bun run format`
- `bun run check`
- `bun run build`
- verified the packed `4.1.0` tarball and its ESM, CommonJS, Zod 3/4/Mini, and SDK consumer matrix
- parsed and checked the final homepage, repository, and bugs values
